### PR TITLE
Use map-monitor API over nadeo, and various improvements

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -8,4 +8,4 @@ siteid = 238
 [script]
 dependencies = [ "NadeoServices" ]
 imports = []
-
+# defines = ["DEV"]

--- a/src/Main.as
+++ b/src/Main.as
@@ -1,9 +1,9 @@
-// Global variables  
+// Global variables
 int totalPlayers = 0;
 
 UserResultVM vm = UserResultVM();
 
-void Render() 
+void Render()
 {
 #if TMNEXT
 
@@ -14,7 +14,7 @@ void Render()
             return;
         }
 
-        if(!UI::IsOverlayShown() && onlyOnOverlay) 
+        if(!UI::IsOverlayShown() && onlyOnOverlay)
         {
             return;
         }
@@ -24,7 +24,7 @@ void Render()
 #endif
 }
 
-void RenderMenu() 
+void RenderMenu()
 {
 #if TMNEXT
     if(UI::MenuItem("\\$f0c\\$s" + Icons::Bold + "\\$z COTD Live Qualifying", "", windowVisible)) {
@@ -33,7 +33,7 @@ void RenderMenu()
 #endif
 }
 
-void Main() 
+void Main()
 {
 #if TMNEXT
 
@@ -50,12 +50,12 @@ void Main()
     array<string> currentAccountIds;
     int friendsRefreshIndicator = 0;
 
-    while (!NadeoServices::IsAuthenticated("NadeoClubServices") && !NadeoServices::IsAuthenticated("NadeoLiveServices")) 
+    while (!NadeoServices::IsAuthenticated("NadeoClubServices") && !NadeoServices::IsAuthenticated("NadeoLiveServices"))
     {
         yield();
     }
 
-    while(true) 
+    while(true)
     {
         if (hasPermissionAndIsCOTDRunning())
         {
@@ -64,7 +64,7 @@ void Main()
             friendsRefreshIndicator++;
             string mapid = network.ClientManiaAppPlayground.Playground.Map.MapInfo.MapUid;
 
-            if (currentChallengeid == 0) 
+            if (currentChallengeid == 0)
             {
                 currentChallengeid = NadeoLiveServicesAPI::GetCurrentCOTDChallengeId();
             }
@@ -88,10 +88,7 @@ void Main()
                     else
                     {
                         currentClubName = "Club: " + ColoredString(NadeoLiveServicesAPI::GetClubName(currentClubId));
-                        //Show warning if more than 100 members
-                        int offset = 0;
-                        int length = 100;
-                        currentAccountIds = NadeoLiveServicesAPI::GetMemberIdsFromClub(currentClubId, offset, length);
+                        currentAccountIds = NadeoLiveServicesAPI::GetAllMemberIdsFromClub(currentClubId);
                     }
                 }
                 currentDisplayMode = Club;
@@ -107,8 +104,8 @@ void Main()
                 }
                 currentDisplayMode = Friends;
             }
-             
-            //Add current user if not already included  
+
+            //Add current user if not already included
             if (currentAccountIds.Find(currentUserId) < 0)
             {
                 currentAccountIds.InsertLast(currentUserId);
@@ -120,7 +117,7 @@ void Main()
             {
                 allResults.InsertLast(playerResults[n]);
             }
-            
+
             allResults.SortAsc();
 
             for(uint n = 0; n < numberOfPlayerDisplay && n < allResults.Length; n++ )

--- a/src/services/api/MapMontior.as
+++ b/src/services/api/MapMontior.as
@@ -1,0 +1,63 @@
+const string MM_API_PROD_ROOT = "https://map-monitor.xk.io";
+const string MM_API_DEV_ROOT = "http://localhost:8000";
+
+// requires `defines = ["DEV"]` in info.toml
+#if DEV
+[Setting category="[DEV] Debug" name="Local Dev Server"]
+bool S_LocalDev = true;
+#else
+bool S_LocalDev = false;
+#endif
+
+const string MM_API_ROOT {
+    get {
+        if (S_LocalDev) return MM_API_DEV_ROOT;
+        else return MM_API_PROD_ROOT;
+    }
+}
+
+namespace MapMonitor {
+    Json::Value@ GetNbPlayersForMap(const string &in mapUid) {
+        return CallMapMonitorApiPath('/map/' + mapUid + '/nb_players/refresh');
+    }
+
+    Json::Value@ GetCotdCurrent() {
+        return CallMapMonitorApiPath("/cached/api/cup-of-the-day/current");
+    }
+
+    Json::Value@ GetChallengeRecords(int challengeId, const string &in mapUid, uint length, uint offset) {
+        return CallMapMonitorApiPath("/cached/api/challenges/" + challengeId + "/records/maps/" + mapUid + "?" + LengthAndOffset(length, offset));
+    }
+
+    Json::Value@ GetChallengeCutoffs(int challengeId, const string &in mapUid) {
+        return CallMapMonitorApiPath("/cached/api/challenges/" + challengeId + "/records/maps/" + mapUid + "?cutoffs");
+    }
+
+    Json::Value@ GetPlayerRank(int challengeid, const string &in mapid, const string &in userId) {
+        return CallMapMonitorApiPath("/cached/api/challenges/" + challengeid + "/records/maps/" + mapid + "/players?players[]=" + userId);
+    }
+
+    Json::Value@ GetPlayersRank(int challengeid, const string &in mapid, const string[]&in userIds) {
+        string players = string::Join(userIds, ",");
+        return CallMapMonitorApiPath("/cached/api/challenges/" + challengeid + "/records/maps/" + mapid + "/players?players[]=" + players);
+    }
+
+    Json::Value@ CallMapMonitorApiPath(const string &in path) {
+        auto url = MM_API_ROOT + path;
+        // trace("[CallMapMonitorApiPath] Requesting: " + url);
+        Net::HttpRequest@ req = Net::HttpRequest();
+        req.Url = url;
+        auto plugin = Meta::ExecutingPlugin();
+        req.Headers['User-Agent'] = plugin.Name + '/' + plugin.Version + '/Openplanet-Plugin/contact=@' + plugin.Author;
+        req.Method = Net::HttpMethod::Get;
+        req.Start();
+        while(!req.Finished()) { yield(); }
+        auto respStr = req.String();
+        // trace("[CallMapMonitorApiPath] Response: " + respStr);
+        return Json::Parse(respStr);
+    }
+
+    const string LengthAndOffset(uint length, uint offset) {
+        return "length=" + length + "&offset=" + offset;
+    }
+}

--- a/src/services/api/NadeoLiveServicesAPI.as
+++ b/src/services/api/NadeoLiveServicesAPI.as
@@ -16,7 +16,7 @@ namespace NadeoLiveServicesAPI
 		{
 			return "Please select a Club in the settings";
 		}
-	    Json::Value@ clubInfo = FetchEndpointLiveServices(nadeoURL + "/api/token/club/" + Text::Format("%d", clubId));
+	    Json::Value@ clubInfo = FetchEndpointLiveServices(nadeoURL + "/api/token/club/" + clubId);
 	    //Check if result was found
 	    if (clubInfo.Length > 1)
 	    {
@@ -29,28 +29,38 @@ namespace NadeoLiveServicesAPI
 
 	}
 
-	array<string> GetMemberIdsFromClub(const int &in clubId, const int &in offset, const int &in length)
+	array<string> GetAllMemberIdsFromClub(const int &in clubId)
 	{
 	    string nadeoURL = NadeoServices::BaseURL();
+		int offset = 0;
+		int length = 100;
 
 		array<string> clubMembers = {};
 	    if (clubId == 0)
 	    {
 	    	return clubMembers;
 	    }
-	    Json::Value@ clubInfo = FetchEndpointLiveServices(nadeoURL + "/api/token/club/" + Text::Format("%d", clubId) + "/member?offset=" + Text::Format("%d", offset) + "&length=" + Text::Format("%d", length));
-	    //Check if result was found
-	    if (clubInfo.Length <= 1)
-	    {
-	    	return {};
-	    }
-	    Json::Value@ members = clubInfo["clubMemberList"];
 
-	    for(uint n = 0; n < members.Length && n < 100; n++)
-	    {
-	        string accountId = members[n]["accountId"];
-	        clubMembers.InsertLast(accountId);
-	    }
+		int maxPage = 1;
+		int currPage = 0;
+		int itemCount = -1;
+		while (currPage < maxPage) {
+			Json::Value@ clubInfo = FetchEndpointLiveServices(nadeoURL + "/api/token/club/" + clubId + "/member?offset=" + offset + "&length=" + length);
+			if (clubInfo.Length <= 1) {
+				break;
+			}
+			Json::Value@ members = clubInfo["clubMemberList"];
+			maxPage = clubInfo['maxPage'];
+			itemCount = clubInfo['itemCount'];
+			offset += length;
+			currPage += 1;
+
+			for(uint n = 0; n < members.Length && n < 100; n++) {
+				string accountId = members[n]["accountId"];
+				clubMembers.InsertLast(accountId);
+			}
+		}
+
 	    return clubMembers;
 	}
 

--- a/src/services/api/NadeoLiveServicesAPI.as
+++ b/src/services/api/NadeoLiveServicesAPI.as
@@ -10,7 +10,7 @@ namespace NadeoLiveServicesAPI
 
 	string GetClubName(const int &in clubId)
 	{
-		string nadeoURL = NadeoServices::BaseURL();
+		string nadeoURL = NadeoServices::BaseURLLive();
 
 		if (clubId == 0)
 		{
@@ -31,7 +31,7 @@ namespace NadeoLiveServicesAPI
 
 	array<string> GetAllMemberIdsFromClub(const int &in clubId)
 	{
-	    string nadeoURL = NadeoServices::BaseURL();
+		string nadeoURL = NadeoServices::BaseURLLive();
 		int offset = 0;
 		int length = 100;
 
@@ -44,7 +44,7 @@ namespace NadeoLiveServicesAPI
 		int maxPage = 1;
 		int currPage = 0;
 		int itemCount = -1;
-		while (currPage < maxPage) {
+		while (currPage < Math::Min(10, maxPage)) {
 			Json::Value@ clubInfo = FetchEndpointLiveServices(nadeoURL + "/api/token/club/" + clubId + "/member?offset=" + offset + "&length=" + length);
 			if (clubInfo.Length <= 1) {
 				break;
@@ -55,10 +55,15 @@ namespace NadeoLiveServicesAPI
 			offset += length;
 			currPage += 1;
 
-			for(uint n = 0; n < members.Length && n < 100; n++) {
+			for(uint n = 0; n < members.Length; n++) {
 				string accountId = members[n]["accountId"];
 				clubMembers.InsertLast(accountId);
 			}
+		}
+		if (maxPage > 10) {
+			auto msg = "Your chosen club has more than 1000 members, but only the first 1000 members are loaded and checked.";
+			UI::ShowNotification(Meta::ExecutingPlugin().Name, msg, vec4(1, .5, 0, 1), 12500);
+			warn(msg);
 		}
 
 	    return clubMembers;
@@ -67,7 +72,7 @@ namespace NadeoLiveServicesAPI
 	//TODO for later: feature to select a club via UI Dropdown.
 	/*array<ClubSelectItem@> GetAllCLubs()
 	{
-		string nadeoURL = NadeoServices::BaseURL();
+		string nadeoURL = NadeoServices::BaseURLLive();
 
 		Json::Value clubResult = FetchEndpointLiveServices(nadeoURL + "/api/token/club/mine?offset=0&length=100");
 		Json::Value clubList = clubResult["clubList"];

--- a/src/settings/settings.as
+++ b/src/settings/settings.as
@@ -1,7 +1,7 @@
 [SettingsTab name="Info"]
 void RenderSettingsAbout() {
     UI::Text("Limitations:");
-    UI::Text("Clubs are supported up to 100 players, otherwise not all results of the players can be tracked.");
+    UI::Text("Clubs are supported up to 1000 players, otherwise not all results of the players can be tracked.");
     UI::Text("Same applies to Uplay friends.");
     UI::Text("Offline Uplay friends will not be tracked.");
     UI::Separator();


### PR DESCRIPTION
**Note: there is a bug atm where sometimes the /players route includes duplicates. Not sure why but FYI.**

This PR does a few things:
- Changes some API methods to use my map-monitor API over nadeo's (The answer to 'why?' is at the end)
- Adds support for up to 1000 club members
- Warns the user when the club is over 1k members (so only the first 1k will be tracked)
- Fixes some deprecation warnings
- Simplifies some code
- Some end-of-line spaces removed automatically

Okay, so why should you change the API endpoint?

Basically plugins are causing Nadeo enough load to be a problem, notably COTD HUD and COTD Stats have been asked to reduce their load (in that order). This is somewhat natural considering COTD HUD made an order of magnitude more requests than COTD Stats.

* Magnetik on COTD HUD: https://discord.com/channels/276076890714800129/951945930159050762/1113747879140540417
  * > [6:36 PM]magnetik: @XertroV I think your plugin COTD hub is spamming like crazy during COTD
    > [6:37 PM]magnetik: around 1000 req/s feels like a little too much
* Magnetik on COTD Stats: https://discord.com/channels/276076890714800129/276076890714800129/1153257991500484619
  * > [7:15 PM]magnetik: Hey COTDStats plugin is spamming our API during COTD way too much
  
COTD Stats is transitioning to my endpoint atm. I've just improve it's performance too. 

It seems reasonable that, since COTD Stats has been asked to reduce load, COTD Live Qualifying might be asked to soon, too. 
Using the map-monitor API will immediately help with reducing load.

The APIs this PR calls are new, and it's hard for me to test them since main COTD is at 3am for me. So I suggest you test this yourself before merging. Hopefully it works okay.